### PR TITLE
Fixed to respect view padding

### DIFF
--- a/src/com/example/touch/TouchImageView.java
+++ b/src/com/example/touch/TouchImageView.java
@@ -377,13 +377,16 @@ public class TouchImageView extends ImageView {
         int widthMode = MeasureSpec.getMode(widthMeasureSpec);
         int heightSize = MeasureSpec.getSize(heightMeasureSpec);
         int heightMode = MeasureSpec.getMode(heightMeasureSpec);
-        viewWidth = setViewSize(widthMode, widthSize, drawableWidth);
-        viewHeight = setViewSize(heightMode, heightSize, drawableHeight);
+        int totalViewWidth = setViewSize(widthMode, widthSize, drawableWidth);
+        int totalViewHeight = setViewSize(heightMode, heightSize, drawableHeight);
+        
+        viewWidth = totalViewWidth - getPaddingLeft() - getPaddingRight();
+        viewHeight = totalViewHeight - getPaddingTop() - getPaddingBottom();
         
         //
         // Set view dimensions
         //
-        setMeasuredDimension(viewWidth, viewHeight);
+        setMeasuredDimension(totalViewWidth, totalViewHeight);
         
         //
         // Fit content within view


### PR DESCRIPTION
Previously, padding was not taken into account when calculating the size of the image, yet the image was still placed within the view with the left and top padding, causing the image to appear offset, as below.

![screenshot_2014-02-23-16-10-53](https://f.cloud.github.com/assets/1720800/2239501/8dc6398a-9c39-11e3-8bbf-076b57663e0b.png)

When zoomed in, you could not see the padding on the right hand side or the bottom.

![screenshot_2014-02-23-16-11-07](https://f.cloud.github.com/assets/1720800/2239503/929f6bc0-9c39-11e3-8885-4ad7ae35bc5a.png)

This fix allows the view to respect any padding specified on the image view. The view fills the entire view area, but then the image itself is sized to fit inside the views padding. This allows any background color etc to fill the view, as expected.

![screenshot_2014-02-23-16-11-29](https://f.cloud.github.com/assets/1720800/2239504/aca7230a-9c39-11e3-933a-0c0b0e236cf7.png)

When zoomed in, you can pan to the edge of the image, and see the padding on all sides.

![screenshot_2014-02-23-16-11-35](https://f.cloud.github.com/assets/1720800/2239505/b2d3aac8-9c39-11e3-9af4-f2dc493826f4.png)

Finally, you can see that this works for non-uniform padding - the following image has `200dp` padding on the right side, with `16dp` on all other sides.

![screenshot_2014-02-23-16-12-07](https://f.cloud.github.com/assets/1720800/2239506/d0686c9a-9c39-11e3-89fb-40d7990e8a47.png)

And zoomed in & panned:

![screenshot_2014-02-23-16-12-13](https://f.cloud.github.com/assets/1720800/2239507/d647b60c-9c39-11e3-87d9-52dfa57dee68.png)

The image in all of the examples except the last one is a `TouchImageView` with the following attributes:

```
    <com.example.TouchImageView
        android:id="@+id/activity_image_overlay"
        android:layout_width="match_parent"
        android:layout_height="match_parent"
        android:padding="16dp"
        android:background="#f00"/>
```