### PR TITLE
Fixed to respect view padding

### DIFF
--- a/src/com/ortiz/touch/TouchImageView.java
+++ b/src/com/ortiz/touch/TouchImageView.java
@@ -524,14 +524,17 @@ public class TouchImageView extends ImageView {
         int widthMode = MeasureSpec.getMode(widthMeasureSpec);
         int heightSize = MeasureSpec.getSize(heightMeasureSpec);
         int heightMode = MeasureSpec.getMode(heightMeasureSpec);
-        viewWidth = setViewSize(widthMode, widthSize, drawableWidth);
-        viewHeight = setViewSize(heightMode, heightSize, drawableHeight);
-        
+        int totalViewWidth = setViewSize(widthMode, widthSize, drawableWidth);
+        int totalViewHeight = setViewSize(heightMode, heightSize, drawableHeight);
+
+        // Image view width, height must consider padding
+        viewWidth = totalViewWidth - getPaddingLeft() - getPaddingRight();
+        viewHeight = totalViewHeight - getPaddingTop() - getPaddingBottom();
+
         //
         // Set view dimensions
         //
-        setMeasuredDimension(viewWidth, viewHeight);
-        
+        setMeasuredDimension(totalViewWidth, totalViewHeight);        
         //
         // Fit content within view
         //


### PR DESCRIPTION
This is a follow-up to #62.

Currently, the `TouchImageView` does not consider padding set on the view when calculating the size of the image to draw. This results in the image being "cut off" on the right and/or bottom edges, as the padding on the left and top serve to "offset" the image.

To solve this, I have simply included view padding in the calculations for the size of the image views drawable area.

This is the original view, without padding:

<img src="https://cloud.githubusercontent.com/assets/1720800/5920425/7d28f7b2-a60a-11e4-8d6c-601fa0588aad.png" height="480" width="270" >

And then, with padding (16dp) - note we can no longer see sky behind the building on the right:

<img src="https://cloud.githubusercontent.com/assets/1720800/5920433/8bfabf8c-a60a-11e4-9940-5561886e3e07.png" height="480" width="270" >

Now, here we see the same image, with padding, with the fix applied:

<img src="https://cloud.githubusercontent.com/assets/1720800/5920482/ce3d8e7e-a60a-11e4-81a4-a46181a55195.png" height="480" width="270" >

In #62 you requested that the view respect padding _while zoomed_ - this can be achieved by the built-in command, [`setCropToPadding(true)`](https://developer.android.com/reference/android/widget/ImageView.html#setCropToPadding%28boolean%29) (`android:cropToPadding="true"` in XML):

<img src="https://cloud.githubusercontent.com/assets/1720800/5920509/0c0eacd8-a60b-11e4-859e-1d2a23f6460a.png" height="480" width="270" >