### PR TITLE
added FIT_START and FIT_END scaletypes

### DIFF
--- a/src/com/ortiz/touch/TouchImageView.java
+++ b/src/com/ortiz/touch/TouchImageView.java
@@ -179,9 +179,6 @@ public class TouchImageView extends ImageView {
     
     @Override
     public void setScaleType(ScaleType type) {
-    	if (type == ScaleType.FIT_START || type == ScaleType.FIT_END) {
-    		throw new UnsupportedOperationException("TouchImageView does not support FIT_START or FIT_END");
-    	}
     	if (type == ScaleType.MATRIX) {
     		super.setScaleType(ScaleType.MATRIX);
     		
@@ -574,6 +571,8 @@ public class TouchImageView extends ImageView {
         	scaleX = scaleY = Math.min(1, Math.min(scaleX, scaleY));
         	
         case FIT_CENTER:
+        case FIT_START:
+        case FIT_END:
         	scaleX = scaleY = Math.min(scaleX, scaleY);
         	break;
         	
@@ -581,11 +580,6 @@ public class TouchImageView extends ImageView {
         	break;
         	
     	default:
-    		//
-    		// FIT_START and FIT_END not supported
-    		//
-    		throw new UnsupportedOperationException("TouchImageView does not support FIT_START or FIT_END");
-        	
         }
 
         //
@@ -600,7 +594,16 @@ public class TouchImageView extends ImageView {
         	// Stretch and center image to fit view
         	//
         	matrix.setScale(scaleX, scaleY);
-        	matrix.postTranslate(redundantXSpace / 2, redundantYSpace / 2);
+        	switch (mScaleType) {
+        	case FIT_START:
+        		matrix.postTranslate(0, 0);
+        		break;
+        	case FIT_END:
+        		matrix.postTranslate(redundantXSpace, redundantYSpace);
+        		break;
+        	default:
+        		matrix.postTranslate(redundantXSpace / 2, redundantYSpace / 2);
+        	}
         	normalizedScale = 1;
         	
         } else {


### PR DESCRIPTION
FIT_START and FIT_END scale types as documented in http://developer.android.com/reference/android/widget/ImageView.ScaleType.html and http://developer.android.com/reference/android/graphics/Matrix.ScaleToFit.html.

Note that when the appliance and TouchImageView rotates from portrait to landscape or vice versa the zoom parameters come from the already drawn object (imageRenderedAtLeastOnce). So in essence this is not a complete solution.
