### PR TITLE
Allow the size to be set for EXACT measure spec mode so the view will…

### DIFF
--- a/touchview/src/main/java/com/ortiz/touchview/TouchImageView.java
+++ b/touchview/src/main/java/com/ortiz/touchview/TouchImageView.java
@@ -634,13 +634,8 @@ public class TouchImageView extends AppCompatImageView {
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         Drawable drawable = getDrawable();
-        if (drawable == null || drawable.getIntrinsicWidth() == 0 || drawable.getIntrinsicHeight() == 0) {
-            setMeasuredDimension(0, 0);
-            return;
-        }
-
-        int drawableWidth = drawable.getIntrinsicWidth();
-        int drawableHeight = drawable.getIntrinsicHeight();
+        int drawableWidth = (drawable == null ? 0 : drawable.getIntrinsicWidth());
+        int drawableHeight = (drawable == null ? 0 : drawable.getIntrinsicHeight());
         int widthSize = MeasureSpec.getSize(widthMeasureSpec);
         int widthMode = MeasureSpec.getMode(widthMeasureSpec);
         int heightSize = MeasureSpec.getSize(heightMeasureSpec);


### PR DESCRIPTION
… still be created the proper size even if no drawable has yet been set.

This is essentially a duplicate of PR #107, but re-applied against the current base. We had a similar issue and solved it the same way via a local copy. The problem was that we were using onSizeChanged() in a subclass of TouchImageView to trigger Picasso to load an image, scaled to the size the view. When first created with no drawable and sized as MATCH_PARENT/MATCH_PARENT, TouchImageView was explicitly measuing itself as 0,0, which would not trigger the onSizeChanged(), so we couldn't load the image.