### PR TITLE
Allow to set custom zoom multiplier when double tap is used.

### DIFF
--- a/touchview/src/main/java/com/ortiz/touchview/TouchImageView.java
+++ b/touchview/src/main/java/com/ortiz/touchview/TouchImageView.java
@@ -77,6 +77,7 @@ public class TouchImageView extends AppCompatImageView {
     private float superMinScale;
     private float superMaxScale;
     private float[] m;
+    private float doubleTapScale;
 
     private Fling fling;
     private int orientation;
@@ -377,6 +378,25 @@ public class TouchImageView extends AppCompatImageView {
         maxScale = max;
         superMaxScale = SUPER_MAX_MULTIPLIER * maxScale;
         maxScaleIsSetByMultiplier = false;
+    }
+
+    /**
+     * Get zoom multiplier for double tap
+     *
+     * @return double tap zoom multiplier.
+     */
+    public float getDoubleTapScale() {
+        return doubleTapScale;
+    }
+
+    /**
+     * Set custom zoom multiplier for double tap.
+     * By default maxScale will be used as value for double tap zoom multiplier.
+     *
+     * @param doubleTapScale zoom multiplier for double tap
+     */
+    public void setDoubleTapScale(float doubleTapScale) {
+        this.doubleTapScale = doubleTapScale;
     }
 
     /**
@@ -1007,7 +1027,8 @@ public class TouchImageView extends AppCompatImageView {
                     consumed = doubleTapListener.onDoubleTap(e);
                 }
                 if (state == State.NONE) {
-                    float targetZoom = (normalizedScale == minScale) ? maxScale : minScale;
+                    float maxZoomScale = (doubleTapScale == 0) ? maxScale : doubleTapScale;
+                    float targetZoom = (normalizedScale == minScale) ? maxZoomScale : minScale;
                     DoubleTapZoom doubleTap = new DoubleTapZoom(targetZoom, e.getX(), e.getY(), false);
                     compatPostOnAnimation(doubleTap);
                     consumed = true;


### PR DESCRIPTION
In my case when maxZoom was set to very large values (almost infinite), double tap was zooming too much. So I added another zoom scale variable for double tap.
Should fix #225. 