### PR TITLE
#234: Make getScrollPosition @NonNullable

### DIFF
--- a/touchview/src/main/java/com/ortiz/touchview/TouchImageView.java
+++ b/touchview/src/main/java/com/ortiz/touchview/TouchImageView.java
@@ -537,7 +537,7 @@ public class TouchImageView extends AppCompatImageView {
     public PointF getScrollPosition() {
         Drawable drawable = getDrawable();
         if (drawable == null) {
-            return null;
+            return new PointF(.5F, .5F);
         }
         int drawableWidth = getDrawableWidth(drawable);
         int drawableHeight = getDrawableHeight(drawable);


### PR DESCRIPTION
This fixes #234 .

I'm not entirely sure what the best return value should be when `getDrawable()` returns null.

Based on the description "Return the point at the center of the zoomed image"., I decided to `return new PointF(.5F, .5F);` Not sure if that has undesired side effects.

