### PR TITLE
do not handle scale events if zoom is disabled

### DIFF
--- a/touchview/src/main/java/com/ortiz/touchview/TouchImageView.java
+++ b/touchview/src/main/java/com/ortiz/touchview/TouchImageView.java
@@ -1040,7 +1040,9 @@ public class TouchImageView extends AppCompatImageView {
                 setState(State.NONE);
                 return false;
             }
-            mScaleDetector.onTouchEvent(event);
+            if (isZoomEnabled()) {
+                mScaleDetector.onTouchEvent(event);
+            }
             mGestureDetector.onTouchEvent(event);
             PointF curr = new PointF(event.getX(), event.getY());
 


### PR DESCRIPTION
It would be logical to completely disable the ability to zoom an image if the corresponding flag is set