### PR TITLE
use float type for zoomTime

### DIFF
--- a/app/src/main/java/info/touchimage/demo/AnimateZoomActivity.kt
+++ b/app/src/main/java/info/touchimage/demo/AnimateZoomActivity.kt
@@ -15,7 +15,10 @@ class AnimateZoomActivity : AppCompatActivity(), TouchImageView.OnZoomFinishedLi
         setContentView(R.layout.activity_single_touchimageview)
 
         current_zoom.setOnClickListener {
-            imageSingle.setZoomAnimated(0.9f, 0.5f, 0f, this)
+            when {
+                imageSingle.isZoomed -> imageSingle.resetZoomAnimated()
+                imageSingle.isZoomed.not() -> imageSingle.setZoomAnimated(0.9f, 0.5f, 0f, this)
+            }
         }
     }
 

--- a/touchview/src/main/java/com/ortiz/touchview/TouchImageView.java
+++ b/touchview/src/main/java/com/ortiz/touchview/TouchImageView.java
@@ -1494,7 +1494,7 @@ public class TouchImageView extends AppCompatImageView {
      */
     private class AnimatedZoom implements Runnable {
 
-        private final int zoomTime;
+        private final float zoomTime;
         private long startTime;
         private float startZoom, targetZoom;
         private PointF startFocus, targetFocus;

--- a/touchview/src/main/java/com/ortiz/touchview/TouchImageView.java
+++ b/touchview/src/main/java/com/ortiz/touchview/TouchImageView.java
@@ -464,6 +464,10 @@ public class TouchImageView extends AppCompatImageView {
         fitImageToView();
     }
 
+    public void resetZoomAnimated() {
+        setZoomAnimated(1f, 0.5f, 0.5f);
+    }
+
     /**
      * Set zoom to the specified scale. Image will be centered by default.
      */


### PR DESCRIPTION
this fixes zoom animation

output with "int":

E: startTime=1580323700404 currTime=1580323700407 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700422 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700439 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700456 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700473 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700490 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700511 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700527 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700541 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700558 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700576 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700593 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700609 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700626 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700643 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700661 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700678 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700695 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700712 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700729 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700746 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700763 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700781 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700797 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700814 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700831 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700849 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700865 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700882 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700899 elapsed=0.0
E: startTime=1580323700404 currTime=1580323700916 elapsed=1.0

output with "float":

E: startTime=1580323763868 currTime=1580323763880 elapsed=0.024
E: startTime=1580323763868 currTime=1580323763897 elapsed=0.058
E: startTime=1580323763868 currTime=1580323763917 elapsed=0.098
E: startTime=1580323763868 currTime=1580323763932 elapsed=0.128
E: startTime=1580323763868 currTime=1580323763952 elapsed=0.168
E: startTime=1580323763868 currTime=1580323763966 elapsed=0.196
E: startTime=1580323763868 currTime=1580323763983 elapsed=0.23
E: startTime=1580323763868 currTime=1580323764000 elapsed=0.264
E: startTime=1580323763868 currTime=1580323764016 elapsed=0.296
E: startTime=1580323763868 currTime=1580323764033 elapsed=0.33
E: startTime=1580323763868 currTime=1580323764050 elapsed=0.364
E: startTime=1580323763868 currTime=1580323764067 elapsed=0.398
E: startTime=1580323763868 currTime=1580323764084 elapsed=0.432
E: startTime=1580323763868 currTime=1580323764099 elapsed=0.462
E: startTime=1580323763868 currTime=1580323764116 elapsed=0.496
E: startTime=1580323763868 currTime=1580323764133 elapsed=0.53
E: startTime=1580323763868 currTime=1580323764150 elapsed=0.564
E: startTime=1580323763868 currTime=1580323764168 elapsed=0.6
E: startTime=1580323763868 currTime=1580323764185 elapsed=0.634
E: startTime=1580323763868 currTime=1580323764204 elapsed=0.672
E: startTime=1580323763868 currTime=1580323764219 elapsed=0.702
E: startTime=1580323763868 currTime=1580323764236 elapsed=0.736
E: startTime=1580323763868 currTime=1580323764254 elapsed=0.772
E: startTime=1580323763868 currTime=1580323764270 elapsed=0.804
E: startTime=1580323763868 currTime=1580323764287 elapsed=0.838
E: startTime=1580323763868 currTime=1580323764304 elapsed=0.872
E: startTime=1580323763868 currTime=1580323764321 elapsed=0.906
E: startTime=1580323763868 currTime=1580323764338 elapsed=0.94
E: startTime=1580323763868 currTime=1580323764354 elapsed=0.972
E: startTime=1580323763868 currTime=1580323764371 elapsed=1.0
