### PR TITLE
convert DEFAULT_ZOOM_TIME to float to prevent animDuration = 0

### DIFF
--- a/touchview/src/main/java/com/ortiz/touchview/TouchImageView.java
+++ b/touchview/src/main/java/com/ortiz/touchview/TouchImageView.java
@@ -1247,7 +1247,7 @@ public class TouchImageView extends AppCompatImageView {
          */
         private float interpolate() {
             long currTime = System.currentTimeMillis();
-            float elapsed = (currTime - startTime) / DEFAULT_ZOOM_TIME;
+            float elapsed = (currTime - startTime) / (float) DEFAULT_ZOOM_TIME;
             elapsed = Math.min(1f, elapsed);
             return interpolator.getInterpolation(elapsed);
         }


### PR DESCRIPTION
@MikeOrtiz can you please create a new release with the latest fixes?