### PR TITLE
Fix NullPointerExceptions in GestureListener

### DIFF
--- a/touchview/src/main/java/com/ortiz/touchview/TouchImageView.kt
+++ b/touchview/src/main/java/com/ortiz/touchview/TouchImageView.kt
@@ -838,15 +838,11 @@ class TouchImageView @JvmOverloads constructor(context: Context, attrs: Attribut
         }
 
         override fun onFling(e1: MotionEvent?, e2: MotionEvent?, velocityX: Float, velocityY: Float): Boolean {
-            if (fling != null) {
-                //
-                // If a previous fling is still active, it should be cancelled so that two flings
-                // are not run simultaenously.
-                //
-                fling!!.cancelFling()
-            }
+            // If a previous fling is still active, it should be cancelled so that two flings
+            // are not run simultaneously.
+            fling?.cancelFling()
             fling = Fling(velocityX.toInt(), velocityY.toInt())
-            compatPostOnAnimation(fling!!)
+                    .also { compatPostOnAnimation(it) }
             return super.onFling(e1, e2, velocityX, velocityY)
         }
 

--- a/touchview/src/main/java/com/ortiz/touchview/TouchImageView.kt
+++ b/touchview/src/main/java/com/ortiz/touchview/TouchImageView.kt
@@ -3,7 +3,11 @@ package com.ortiz.touchview
 import android.annotation.TargetApi
 import android.content.Context
 import android.content.res.Configuration
-import android.graphics.*
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Matrix
+import android.graphics.PointF
+import android.graphics.RectF
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Build.VERSION
@@ -823,17 +827,17 @@ class TouchImageView @JvmOverloads constructor(context: Context, attrs: Attribut
      * to the view's listener.
      */
     private inner class GestureListener : SimpleOnGestureListener() {
-        override fun onSingleTapConfirmed(e: MotionEvent): Boolean {
+        override fun onSingleTapConfirmed(e: MotionEvent?): Boolean {
             return if (doubleTapListener != null) {
                 doubleTapListener!!.onSingleTapConfirmed(e)
             } else performClick()
         }
 
-        override fun onLongPress(e: MotionEvent) {
+        override fun onLongPress(e: MotionEvent?) {
             performLongClick()
         }
 
-        override fun onFling(e1: MotionEvent, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
+        override fun onFling(e1: MotionEvent?, e2: MotionEvent?, velocityX: Float, velocityY: Float): Boolean {
             if (fling != null) {
                 //
                 // If a previous fling is still active, it should be cancelled so that two flings
@@ -846,9 +850,9 @@ class TouchImageView @JvmOverloads constructor(context: Context, attrs: Attribut
             return super.onFling(e1, e2, velocityX, velocityY)
         }
 
-        override fun onDoubleTap(e: MotionEvent): Boolean {
+        override fun onDoubleTap(e: MotionEvent?): Boolean {
             var consumed = false
-            if (isZoomEnabled) {
+            if (e != null && isZoomEnabled) {
                 if (doubleTapListener != null) {
                     consumed = doubleTapListener!!.onDoubleTap(e)
                 }
@@ -863,7 +867,7 @@ class TouchImageView @JvmOverloads constructor(context: Context, attrs: Attribut
             return consumed
         }
 
-        override fun onDoubleTapEvent(e: MotionEvent): Boolean {
+        override fun onDoubleTapEvent(e: MotionEvent?): Boolean {
             return if (doubleTapListener != null) {
                 doubleTapListener!!.onDoubleTapEvent(e)
             } else false

--- a/touchview/src/main/java/com/ortiz/touchview/TouchImageView.kt
+++ b/touchview/src/main/java/com/ortiz/touchview/TouchImageView.kt
@@ -828,9 +828,8 @@ class TouchImageView @JvmOverloads constructor(context: Context, attrs: Attribut
      */
     private inner class GestureListener : SimpleOnGestureListener() {
         override fun onSingleTapConfirmed(e: MotionEvent?): Boolean {
-            return if (doubleTapListener != null) {
-                doubleTapListener!!.onSingleTapConfirmed(e)
-            } else performClick()
+            // Pass on to the OnDoubleTapListener if it is present, otherwise let the View handle the click.
+            return doubleTapListener?.onSingleTapConfirmed(e) ?: performClick()
         }
 
         override fun onLongPress(e: MotionEvent?) {
@@ -849,8 +848,9 @@ class TouchImageView @JvmOverloads constructor(context: Context, attrs: Attribut
         override fun onDoubleTap(e: MotionEvent?): Boolean {
             var consumed = false
             if (e != null && isZoomEnabled) {
-                if (doubleTapListener != null) {
-                    consumed = doubleTapListener!!.onDoubleTap(e)
+                val currentDoubleTapListener = doubleTapListener
+                if (currentDoubleTapListener != null) {
+                    consumed = currentDoubleTapListener.onDoubleTap(e)
                 }
                 if (state == State.NONE) {
                     val maxZoomScale = if (doubleTapScale == 0f) maxScale else doubleTapScale
@@ -864,9 +864,7 @@ class TouchImageView @JvmOverloads constructor(context: Context, attrs: Attribut
         }
 
         override fun onDoubleTapEvent(e: MotionEvent?): Boolean {
-            return if (doubleTapListener != null) {
-                doubleTapListener!!.onDoubleTapEvent(e)
-            } else false
+            return doubleTapListener?.onDoubleTapEvent(e) ?: false
         }
     }
 

--- a/touchview/src/main/java/com/ortiz/touchview/TouchImageView.kt
+++ b/touchview/src/main/java/com/ortiz/touchview/TouchImageView.kt
@@ -848,9 +848,8 @@ class TouchImageView @JvmOverloads constructor(context: Context, attrs: Attribut
         override fun onDoubleTap(e: MotionEvent?): Boolean {
             var consumed = false
             if (e != null && isZoomEnabled) {
-                val currentDoubleTapListener = doubleTapListener
-                if (currentDoubleTapListener != null) {
-                    consumed = currentDoubleTapListener.onDoubleTap(e)
+                doubleTapListener?.let {
+                    consumed = it.onDoubleTap(e)
                 }
                 if (state == State.NONE) {
                     val maxZoomScale = if (doubleTapScale == 0f) maxScale else doubleTapScale


### PR DESCRIPTION
We recently upgraded our app to version 3.0.1 and a couple new NPEs bubbled up:
```
Fatal Exception: java.lang.IllegalArgumentException: Parameter specified as non-null is null: method kotlin.v.d.q.b, parameter e1
   at com.ortiz.touchview.TouchImageView$GestureListener.onFling(TouchImageView.java:837)
   at android.view.GestureDetector.onTouchEvent(GestureDetector.java:650)
   at com.ortiz.touchview.TouchImageView$PrivateOnTouchListener.onTouch(TouchImageView.java:893)
   at android.view.View.dispatchTouchEvent(View.java:10068)
   at android.view.ViewGroup.dispatchTransformedTouchEvent(ViewGroup.java:2632)
   [...]
   at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
   at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1445)
```

It looks like Kotlin throws an exception when Android passes null values to the GestureListener methods because the arguments do not have an nullable type:
```kotlin
override fun onFling(e1: MotionEvent, e2: MotionEvent, velocityX: Float, velocityY: Float): Boolean {
  ...
}
```

I also took the liberty to clean up the null checks for the `fling` and `doubleTapListener` fields to avoid forcing nullability with `!!`.