### PR TITLE
Align nullability with parent class

### DIFF
--- a/touchview/src/main/java/com/ortiz/touchview/TouchImageView.kt
+++ b/touchview/src/main/java/com/ortiz/touchview/TouchImageView.kt
@@ -128,7 +128,7 @@ open class TouchImageView @JvmOverloads constructor(context: Context, attrs: Att
         isRotateImageToFitScreen = rotateImageToFitScreen
     }
 
-    override fun setOnTouchListener(onTouchListener: OnTouchListener) {
+    override fun setOnTouchListener(onTouchListener: OnTouchListener?) {
         userTouchListener = onTouchListener
     }
 
@@ -151,7 +151,7 @@ open class TouchImageView @JvmOverloads constructor(context: Context, attrs: Att
         fitImageToView()
     }
 
-    override fun setImageBitmap(bm: Bitmap) {
+    override fun setImageBitmap(bm: Bitmap?) {
         imageRenderedAtLeastOnce = false
         super.setImageBitmap(bm)
         savePreviousImageValues()


### PR DESCRIPTION
These two methods should align the signature with the parent class of `TouchImageView`.

So that we can call `setOnTouchListener(null)` to reset the current touch listener and `setImageBitmap(null)` to reset the current bitmap.

When integrating with Glide, its default behavior invokes `setImageBitmap(null)` to reset the ImageView which crashes the `TouchImageVIew`.

The current workaround is writing a `CustomTarget` and routing to `TouchImageView.setImageDrawable(null)`. This approach is a bit tricky, so I hope this library can fix the root cause.