### PR TITLE
Fix a crash when a configuration change would happen (ie: rotate the device)

### DIFF
--- a/touchview/src/main/java/com/ortiz/touchview/TouchImageView.kt
+++ b/touchview/src/main/java/com/ortiz/touchview/TouchImageView.kt
@@ -20,6 +20,8 @@ import android.view.animation.AccelerateDecelerateInterpolator
 import android.view.animation.LinearInterpolator
 import android.widget.OverScroller
 import androidx.appcompat.widget.AppCompatImageView
+import androidx.core.os.BundleCompat
+import androidx.core.os.bundleOf
 import kotlin.math.abs
 import kotlin.math.max
 import kotlin.math.min
@@ -226,25 +228,27 @@ open class TouchImageView @JvmOverloads constructor(context: Context, attrs: Att
         }
     }
 
-    public override fun onSaveInstanceState(): Parcelable? {
-        super.onSaveInstanceState()
-        val bundle = Bundle()
-        bundle.putInt("orientation", orientation)
-        bundle.putFloat("saveScale", currentZoom)
-        bundle.putFloat("matchViewHeight", matchViewHeight)
-        bundle.putFloat("matchViewWidth", matchViewWidth)
-        bundle.putInt("viewWidth", viewWidth)
-        bundle.putInt("viewHeight", viewHeight)
+    public override fun onSaveInstanceState(): Parcelable {
         touchMatrix.getValues(floatMatrix)
-        bundle.putFloatArray("matrix", floatMatrix)
-        bundle.putBoolean("imageRendered", imageRenderedAtLeastOnce)
-        bundle.putSerializable("viewSizeChangeFixedPixel", viewSizeChangeFixedPixel)
-        bundle.putSerializable("orientationChangeFixedPixel", orientationChangeFixedPixel)
-        return bundle
+
+        return bundleOf(
+            "parent" to super.onSaveInstanceState(),
+            "orientation" to orientation,
+            "saveScale" to currentZoom,
+            "matchViewHeight" to matchViewHeight,
+            "matchViewWidth" to matchViewWidth,
+            "viewWidth" to viewWidth,
+            "viewHeight" to viewHeight,
+            "matrix" to floatMatrix,
+            "imageRendered" to imageRenderedAtLeastOnce,
+            "viewSizeChangeFixedPixel" to viewSizeChangeFixedPixel,
+            "orientationChangeFixedPixel" to orientationChangeFixedPixel
+        )
     }
 
     public override fun onRestoreInstanceState(state: Parcelable) {
         if (state is Bundle) {
+            super.onRestoreInstanceState(BundleCompat.getParcelable(state, "parent", Parcelable::class.java))
             currentZoom = state.getFloat("saveScale")
             floatMatrix = state.getFloatArray("matrix")!!
             prevMatrix.setValues(floatMatrix)


### PR DESCRIPTION
On the latest version of (3.7) a crash happens if you try to rotate the device for example with the following stack trace

```Process: com.ortiz.touchdemo, PID: 12453
java.lang.IllegalStateException: Derived class did not call super.onRestoreInstanceState()
	at android.view.View.dispatchRestoreInstanceState(View.java:21079)
	at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:4006)
	at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:4006)
	at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:4006)
	at android.view.ViewGroup.dispatchRestoreInstanceState(ViewGroup.java:4006)
	at android.view.View.restoreHierarchyState(View.java:21055)
	at com.android.internal.policy.PhoneWindow.restoreHierarchyState(PhoneWindow.java:2200)
	at android.app.Activity.onRestoreInstanceState(Activity.java:1725)
	at android.app.Activity.performRestoreInstanceState(Activity.java:1678)
	at android.app.Instrumentation.callActivityOnRestoreInstanceState(Instrumentation.java:1388)
	at android.app.ActivityThread.handleStartActivity(ActivityThread.java:3748)
	at android.app.servertransaction.TransactionExecutor.performLifecycleSequence(TransactionExecutor.java:221)
	at android.app.servertransaction.TransactionExecutor.cycleToPath(TransactionExecutor.java:201)
	at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:173)
	at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2253)
	at android.os.Handler.dispatchMessage(Handler.java:106)
	at android.os.Looper.loopOnce(Looper.java:201)
	at android.os.Looper.loop(Looper.java:288)
	at android.app.ActivityThread.main(ActivityThread.java:7870)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)```
